### PR TITLE
Sidebar navigation button fix

### DIFF
--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -20,11 +20,11 @@ export function MenuItemButton({
 }: MenuItemProps) {
   return (
     <li className={classNames(styles.listItem, className)}>
-      <Button className={styles.anchor} onClick={onClick}>
+      <button className={styles.button} onClick={onClick}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img className={styles.icon} src={iconSrc} alt={`${text} icon`} />{" "}
         {!isCollapsed && text}{" "}
-      </Button>
+      </button>
     </li>
   );
 }

--- a/features/layout/sidebar-navigation/menu-item-link.module.scss
+++ b/features/layout/sidebar-navigation/menu-item-link.module.scss
@@ -24,8 +24,9 @@
   align-items: center;
   color: color.$gray-100;
   text-decoration: none;
-  transition-duration: .4s;
-  &:hover{
+  transition-duration: 0.4s;
+
+  &:hover {
     color: color.$gray-500;
   }
 }
@@ -42,7 +43,8 @@
   text-decoration: none;
   background: transparent;
   border-color: transparent;
-  transition-duration: .4s;
+  transition-duration: 0.4s;
+
   &:hover {
     color: color.$gray-500;
   }

--- a/features/layout/sidebar-navigation/menu-item-link.module.scss
+++ b/features/layout/sidebar-navigation/menu-item-link.module.scss
@@ -24,9 +24,26 @@
   align-items: center;
   color: color.$gray-100;
   text-decoration: none;
+  transition-duration: .4s;
+  &:hover{
+    color: color.$gray-500;
+  }
 }
 
 .icon {
   width: space.$s6;
   margin-right: space.$s3;
+}
+
+.button {
+  display: flex;
+  align-items: center;
+  color: color.$gray-100;
+  text-decoration: none;
+  background: transparent;
+  border-color: transparent;
+  transition-duration: .4s;
+  &:hover {
+    color: color.$gray-500;
+  }
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -58,7 +58,7 @@ export function SidebarNavigation() {
             alt="logo"
             className={styles.logo}
           />
-          <Button
+          <button
             onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}
             className={styles.menuButton}
           >
@@ -68,7 +68,7 @@ export function SidebarNavigation() {
               alt={isMobileMenuOpen ? "close menu" : "open menu"}
               className={styles.menuIcon}
             />
-          </Button>
+          </button>
         </header>
         <div
           className={classNames(

--- a/features/ui/button/button.module.scss
+++ b/features/ui/button/button.module.scss
@@ -21,26 +21,25 @@
   }
 }
 
-.primary{
+.primary {
   color: color.$primary-600;
 
-  :hover{
+  :hover {
     color: color.$primary-700;
   }
 
-  :focus{
+  :focus {
     color: color.$primary-600;
     border: 4px;
     border-color: color.$primary-100;
   }
 }
 
-.secondary{
+.secondary {
   color: color.$primary-50;
 }
 
-.xl{
+.xl {
   width: 128px;
   height: 48px;
 }
-


### PR DESCRIPTION
Sidebar buttons do not follow styling defined by figma site wide buttons. Needed to decouple sidebar buttons from our own class of buttons. Also added some transitions to the buttons when they are hovered over.